### PR TITLE
Fix icns generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mkdirp": "^0.5.1",
     "node-uuid": "^1.4.7",
     "pngjs": "^2.3.1",
-    "svg2png": "^3.0.0"
+    "svg2png": "3.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",

--- a/src/lib/icns-generator.js
+++ b/src/lib/icns-generator.js
@@ -34,11 +34,7 @@ export const IcnsConstants = {
     { id: 'ic07', size:  128 },
     { id: 'ic08', size:  256 },
     { id: 'ic09', size:  512 },
-    { id: 'ic10', size: 1024 },
-    { id: 'ic11', size:   32 },
-    { id: 'ic12', size:   64 },
-    { id: 'ic13', size:  256 },
-    { id: 'ic14', size:  512 }
+    { id: 'ic10', size: 1024 }
   ]
 };
 


### PR DESCRIPTION
See #42.
Don't know why retina icons (ic11-14) breaks the icns file, but when I remove them it's working.