### PR TITLE
add sizes option to define witch size of png to include

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ options:
 |  modes |   Array | Mode of output files. Allow value is a `ico`, `icns`, `favicon` and `all`. Default is `all`. |
 |  names |  Object | Change an output file names for **ICO** and **ICNS**. |
 | report | Boolean | Display the process reports. Default is `false`, disable a report. |
+|  sizes |  Object | List of sizes to include for **ICO** and **ICNS**. |
 
 names:
 
@@ -132,6 +133,15 @@ Use this property is specified without an extension. Default name is the `app`.
 |:--------|:--|:--|
 | ico | String | Name of the `ico` file. |
 | icns | String | Name of the `icns` file. |
+
+sizes:
+
+Use this property is specified without an extension. Default name is the `app`.
+
+| Name | Type | Description |
+|:--------|:--|:--|
+| ico | Array | List of sizes for the `ico` file. |
+| icns | Array | List of sizes for the `icns` file. |
 
 ## CLI
 
@@ -164,6 +174,9 @@ Usage: icon-gen [OPTIONS]
 
     -r, --report  Display the process reports.
                   Default is disable.
+
+    -s, --sizes   List of sizes to include for ICO and ICNS.
+              ex: 'ico=[12,24,32],icns=[12,24,64]'
 
   Examples:
     $ icon-gen -i sample.svg -o ./dist -r

--- a/src/bin/cli-util.js
+++ b/src/bin/cli-util.js
@@ -16,6 +16,7 @@ export const CLI = {
     output: ['-o', '--output'],
     type: ['-t', '--type'],
     modes: ['-m', '--modes'],
+    sizes: ['-s', '--sizes'],
     names: ['-n', '--names'],
     report: ['-r', '--report']
   },
@@ -52,7 +53,13 @@ export const CLI = {
   names: {
     ico: 'ico',
     icns: 'icns'
-  }
+  },
+
+  /**
+   * Input sizes.
+   * @type {Object}
+   */
+  sizes: []
 }
 
 /**
@@ -88,6 +95,9 @@ Options:
 
 -r, --report  Display the process reports.
           Default is disable.
+
+-s, --sizes   Change an varietion of input files.
+          ex: 'ico=[12,24,32],icns=[12,24,64]'
 
 Examples:
 $ icon-gen -i sample.svg -o ./dist -r
@@ -217,6 +227,13 @@ export default class CLIUtil {
           }
           break
 
+        case CLI.options.sizes[0]:
+        case CLI.options.sizes[1]:
+          if (index + 1 < argv.length) {
+            options.sizes = CLIUtil._parseSizes(argv[index + 1])
+          }
+          break
+
         default:
           break
       }
@@ -294,5 +311,43 @@ export default class CLIUtil {
     })
 
     return names
+  }
+
+  /**
+   * Parse the input file sizes.
+   *
+   * @param {String} arg Option. Format is a 'ico=[16,24,32],icns=[16,24,32]'.
+   *
+   * @return {Object} File sizes.
+   */
+  static _parseSizes (arg) {
+    const sizes = {}
+    if (!(typeof arg === 'string')) {
+      return sizes
+    }
+
+    const regexp = new RegExp(/((ico|icns)=\[[0-9,]+\])/g)
+
+    const params = arg.match(regexp)
+    params.forEach((param) => {
+      const units = param.split('=')
+      if (units.length < 2) {
+        return
+      }
+
+      const key   = units[0]
+      const values = units[1].match(/\[([0-9,]+)\]/)[1].split(',')
+      switch (key) {
+        case CLI.names.ico:
+        case CLI.names.icns:
+          sizes[key] = values
+          break
+
+        default:
+          break
+      }
+    })
+
+    return sizes
   }
 }

--- a/src/bin/cli-util.js
+++ b/src/bin/cli-util.js
@@ -59,7 +59,7 @@ export const CLI = {
    * Input sizes.
    * @type {Object}
    */
-  sizes: []
+  sizes: {}
 }
 
 /**
@@ -96,7 +96,7 @@ Options:
 -r, --report  Display the process reports.
           Default is disable.
 
--s, --sizes   Change an varietion of input files.
+-s, --sizes   List of sizes to include for ICO and ICNS.
           ex: 'ico=[12,24,32],icns=[12,24,64]'
 
 Examples:
@@ -339,7 +339,7 @@ export default class CLIUtil {
         return
       }
 
-      const key   = units[0]
+      const key    = units[0]
       const values = units[1].match(/\[([0-9,]+)\]/)[1].split(',')
       switch (key) {
         case CLI.names.ico:

--- a/src/bin/cli-util.js
+++ b/src/bin/cli-util.js
@@ -247,6 +247,10 @@ export default class CLIUtil {
       options.modes = CLI.modeAll
     }
 
+    if (!(options.sizes)) {
+      options.sizes = {}
+    }
+
     return options
   }
 

--- a/src/bin/cli-util.test.js
+++ b/src/bin/cli-util.test.js
@@ -133,4 +133,27 @@ describe('CLIUtil', () => {
       assert.deepEqual({}, names)
     })
   })
+
+  /** @test {CLIUtil#_parseSizes} */
+  describe('_parseSizes', () => {
+    it('ico & icns', () => {
+      const sizes = CLIUtil._parseSizes('ico=[16,24,32],icns=[16,24,64]')
+      assert.deepEqual({ ico: ['16', '24', '32'], icns: ['16', '24', '64'] }, sizes)
+    })
+
+    it('ico', () => {
+      const sizes = CLIUtil._parseSizes('ico=[16,24,32]')
+      assert.deepEqual({ ico: ['16', '24', '32'] }, sizes)
+    })
+
+    it('icns', () => {
+      const sizes = CLIUtil._parseSizes('icns=[16,24,64]')
+      assert.deepEqual({ icns: ['16', '24', '64'] }, sizes)
+    })
+
+    it('Invalid value', () => {
+      const sizes = CLIUtil._parseSizes()
+      assert.deepEqual({}, sizes)
+    })
+  })
 })

--- a/src/lib/icon-generator.js
+++ b/src/lib/icon-generator.js
@@ -137,7 +137,7 @@ export default class IconGenerator {
 
         case CLI.modes.favicon:
           path = Path.join(dir, 'favicon.ico')
-          tasks.push(ICOGenerator.generate(IconGenerator.filter(images, Favicon.ImageSizes), path, logger))
+          tasks.push(ICOGenerator.generate(IconGenerator.filter(images, Favicon.icoImageSizes), path, logger))
           tasks.push(FaviconGenerator.generate(IconGenerator.filter(images, Favicon.imageSizes), dir, logger))
           break
 

--- a/src/lib/icon-generator.js
+++ b/src/lib/icon-generator.js
@@ -69,7 +69,8 @@ export default class IconGenerator {
       logger.log('  src: ' + pngDirPath)
       logger.log('  dir: ' + destDirPath)
 
-      const images = options.sizes[options.modes] || PngGenerator.getRequiredImageSizes(options.modes)
+      const sizes = options.sizes[options.modes] || PngGenerator.getRequiredImageSizes(options.modes)
+      const images = sizes
       .map((size) => {
         return Path.join(pngDirPath, size + '.png')
       })

--- a/src/lib/icon-generator.js
+++ b/src/lib/icon-generator.js
@@ -68,7 +68,6 @@ export default class IconGenerator {
       logger.log('Icon generetor from PNG:')
       logger.log('  src: ' + pngDirPath)
       logger.log('  dir: ' + destDirPath)
-
       const sizes = options.sizes[options.modes] || PngGenerator.getRequiredImageSizes(options.modes)
       const images = sizes
       .map((size) => {
@@ -126,17 +125,19 @@ export default class IconGenerator {
       switch (mode) {
         case CLI.modes.ico:
           path = Path.join(dir, options.names.ico + '.ico')
-          tasks.push(ICOGenerator.generate(IconGenerator.filter(images, ICO.imageSizes), path, logger))
+          const icoImageFilter = options.sizes['ico'] || ICO.imageSizes
+          tasks.push(ICOGenerator.generate(IconGenerator.filter(images, icoImageFilter), path, logger))
           break
 
         case CLI.modes.icns:
           path = Path.join(dir, options.names.icns + '.icns')
-          tasks.push(ICNSGenerator.generate(IconGenerator.filter(images, ICNS.imageSizes), path, logger))
+          const icnsImageFilter = options.sizes['ico'] || ICNS.imageSizes
+          tasks.push(ICNSGenerator.generate(IconGenerator.filter(images, icnsImageFilter), path, logger))
           break
 
         case CLI.modes.favicon:
           path = Path.join(dir, 'favicon.ico')
-          tasks.push(ICOGenerator.generate(IconGenerator.filter(images, Favicon.icoImageSizes), path, logger))
+          tasks.push(ICOGenerator.generate(IconGenerator.filter(images, Favicon.ImageSizes), path, logger))
           tasks.push(FaviconGenerator.generate(IconGenerator.filter(images, Favicon.imageSizes), dir, logger))
           break
 

--- a/src/lib/icon-generator.js
+++ b/src/lib/icon-generator.js
@@ -69,7 +69,7 @@ export default class IconGenerator {
       logger.log('  src: ' + pngDirPath)
       logger.log('  dir: ' + destDirPath)
 
-      const images = PngGenerator.getRequiredImageSizes(options.modes)
+      const images = options.sizes[options.modes] || PngGenerator.getRequiredImageSizes(options.modes)
       .map((size) => {
         return Path.join(pngDirPath, size + '.png')
       })

--- a/src/lib/icon-generator.test.js
+++ b/src/lib/icon-generator.test.js
@@ -11,7 +11,7 @@ import {Favicon} from './favicon-generator.js'
 describe('IconGenerator', () => {
   /** @test {IconGenerator#fromPNG} */
   it('fromPNG', () => {
-    return IconGenerator.fromPNG('./examples/data', './examples/data', {modes: [], names: {ico: 'app', icns: 'app'}}, new Logger())
+    return IconGenerator.fromPNG('./examples/data', './examples/data', {modes: [], names: {ico: 'app', icns: 'app'}, sizes: {}}, new Logger())
     .then((results) => {
       assert(results)
       TestUtil.deleteFiles(results)


### PR DESCRIPTION
required sizes are predefined, but *.ico can include any size and combination of icons.
with this option, you can define sizes to use instead `ICO.imageSizes`, `ICNS.imageSizes`

```
const options = {
  type: 'png',
  sizes: {
    ico: [16, 24, 32],
    icns: [16, 24, 68]
  }
};
```

```
icon-gen -i ./images -o ./dist -t png -s ico=[12,24,32],icns=[12,24,64]
```