### PR TITLE
Fix generating icons without specifying sizes

### DIFF
--- a/src/lib/icon-generator.js
+++ b/src/lib/icon-generator.js
@@ -69,7 +69,7 @@ export default class IconGenerator {
       logger.log('  src: ' + pngDirPath)
       logger.log('  dir: ' + destDirPath)
 
-      const images = IconGenerator._getRequiredImageSizes(options.modes, options.sizes)
+      const images = IconGenerator._getRequiredImageSizes(options)
         .map((size) => {
           return Path.join(pngDirPath, size + '.png')
         })
@@ -100,19 +100,19 @@ export default class IconGenerator {
     })
   }
 
-  static _getRequiredImageSizes (modes, sizes) {
-    if (!(sizes)) {
-      return PngGenerator.getRequiredImageSizes(modes)
+  static _getRequiredImageSizes (options) {
+    if (!(options.sizes)) {
+      return PngGenerator.getRequiredImageSizes(options)
     }
 
     let imageSizes = []
-    modes.forEach((mode) => {
-      if (sizes[mode]) {
-        imageSizes = imageSizes.concat(sizes[mode])
+    options.modes.forEach((mode) => {
+      if (options.sizes[mode]) {
+        imageSizes = imageSizes.concat(options.sizes[mode])
       }
     })
 
-    return 0 < imageSizes.length ? imageSizes : PngGenerator.getRequiredImageSizes(modes)
+    return 0 < imageSizes.length ? imageSizes : PngGenerator.getRequiredImageSizes(options)
   }
 
   /**

--- a/src/lib/icon-generator.test.js
+++ b/src/lib/icon-generator.test.js
@@ -18,41 +18,41 @@ describe('IconGenerator', () => {
   describe('_getRequiredImageSizes', () => {
     it('ico, icns, favicon', () => {
       const modes = ['ico', 'icns', 'favicon']
-      let actual = IconGenerator._getRequiredImageSizes(modes)
-      let expected = PNGGenerator.getRequiredImageSizes(modes)
+      let actual = IconGenerator._getRequiredImageSizes({modes: modes})
+      let expected = PNGGenerator.getRequiredImageSizes({modes: modes})
       assert.deepStrictEqual(actual, expected)
     })
 
     it('ico', () => {
       const modes = ['ico']
-      const actual = IconGenerator._getRequiredImageSizes(modes)
-      const expected = PNGGenerator.getRequiredImageSizes(modes)
+      const actual = IconGenerator._getRequiredImageSizes({modes: modes})
+      const expected = PNGGenerator.getRequiredImageSizes({modes: modes})
       assert.deepStrictEqual(actual, expected)
     })
 
     it('icns', () => {
       const modes = ['icns']
-      const actual = IconGenerator._getRequiredImageSizes(modes)
-      const expected = PNGGenerator.getRequiredImageSizes(modes)
+      const actual = IconGenerator._getRequiredImageSizes({modes: modes})
+      const expected = PNGGenerator.getRequiredImageSizes({modes: modes})
       assert.deepStrictEqual(actual, expected)
     })
 
     it('favicon', () => {
       const modes = ['favicon']
-      const actual = IconGenerator._getRequiredImageSizes(modes)
-      const expected = PNGGenerator.getRequiredImageSizes(modes)
+      const actual = IconGenerator._getRequiredImageSizes({modes: modes})
+      const expected = PNGGenerator.getRequiredImageSizes({modes: modes})
       assert.deepStrictEqual(actual, expected)
     })
 
     it('ico: sizes', () => {
       const sizes  = [16, 32]
-      const actual = IconGenerator._getRequiredImageSizes(['ico'], {ico: sizes})
+      const actual = IconGenerator._getRequiredImageSizes({modes: ['ico'], sizes: {ico: sizes}})
       assert.deepStrictEqual(actual, sizes)
     })
 
     it('icns: sizes', () => {
       const sizes  = [64, 128]
-      const actual = IconGenerator._getRequiredImageSizes(['icns'], {icns: sizes})
+      const actual = IconGenerator._getRequiredImageSizes({modes: ['icns'], sizes: {icns: sizes}})
       assert.deepStrictEqual(actual, sizes)
     })
   })


### PR DESCRIPTION
It appears that 8ed67a9 broke the ability to generate icons without specifying sizes manually, at least when require()'ing icon-gen. I found that IconGenerator.fromPNG() and IconGenerator._getRequiredImageSizes() were not updated to reflect the API change.