### PR TITLE
change to sharp

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "del": "^6.0.0",
     "mkdirp": "^1.0.4",
     "pngjs": "^6.0.0",
+    "sharp": "^0.29.3",
     "svg2png": "4.1.1",
     "uuid": "^8.3.1"
   },
@@ -50,6 +51,7 @@
     "@types/mkdirp": "^1.0.1",
     "@types/node": "^14.14.10",
     "@types/pngjs": "^3.4.2",
+    "@types/sharp": "^0.29.3",
     "@types/svg2png": "^4.1.0",
     "@types/uuid": "^8.3.0",
     "jest": "^26.6.3",

--- a/src/lib/png.ts
+++ b/src/lib/png.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import util from 'util'
-import svg2png from 'svg2png'
+import sharp from 'sharp'
 import Logger from './logger'
 
 /** Image file information. */
@@ -47,13 +47,11 @@ const generate = async (
   const dest = path.join(dir, size + '.png')
   logger.log('  Create: ' + dest)
 
-  const buffer = svg2png.sync(svg, { width: size, height: size })
-  if (!buffer) {
-    throw new Error('Failed to write the image, ' + size + 'x' + size)
-  }
+  await sharp(svg)
+  .png({ compressionLevel: 9 })
+  .resize(size, size)
+  .toFile(dest)
 
-  const writeFileAsync = util.promisify(fs.writeFile)
-  await writeFileAsync(dest, buffer)
   return { size: size, filePath: dest }
 }
 


### PR DESCRIPTION
to allow removing unmaintained phantomjs

see test run: https://github.com/mifi/npm-icon-gen/actions/runs/1463542851

Until this PR is merged it's possible to install this instead:
```
yarn add @mifi/npm-icon-gen
```