### PR TITLE
chore: Update Node.js support to version 12 or later and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ SVG and PNG are automatically selected from the `input` path. If the path indica
 
 ### SVG
 
-SVG files are rendering to PNG file in **svg2png**. Rendering files is output to a temporary directory of the each OS.
-
-Rendering of svg2png is run by [phantomjs](https://www.npmjs.com/package/phantomjs). Please use the PNG directory If the rendering quality there is a problem.
+SVG files are rendering to PNG file in [sharp](https://www.npmjs.com/package/sharp). Rendering files is output to a temporary directory of the each OS.
 
 ```js
 const icongen = require('icon-gen')
@@ -44,20 +42,30 @@ icongen('./sample.svg', './icons', { report: true })
   })
 ```
 
+Stopped using [svg2png](https://www.npmjs.com/package/svg2png) because of its dependency on [phantomjs](https://www.npmjs.com/package/phantomjs), which is deprecated.
+
+The quality of PNG generated from SVG will change, so if you need the previous results, use icon-gen v2.1.0.
+
+```
+$ npm install icon-gen@2.1.0
+```
+
+In the future, I may add SVG to PNG conversion by Chromium via [puppeteer-core](https://www.npmjs.com/package/puppeteer-core) in addition to [sharp](https://www.npmjs.com/package/sharp).
+
 ### PNG
 
 Generate an icon files from the directory of PNG files.
 
 ```js
-const icongen = require('icon-gen');
+const icongen = require('icon-gen')
 
 icongen('./images', './icons', { report: true })
-.then((results) => {
-  console.log(results);
-} )
-.catch((err) => {
-  console.error(err);
-});
+  .then((results) => {
+    console.log(results)
+  })
+  .catch((err) => {
+    console.error(err)
+  })
 ```
 
 Required PNG files is below. Favicon outputs both the ICO and PNG files (see: [audreyr/favicon-cheat-sheet](https://github.com/audreyr/favicon-cheat-sheet)).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "homepage": "https://github.com/akabekobeko/npm-icon-gen#readme",
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "main": "dist/lib/index.js",
   "bin": {
@@ -37,25 +37,23 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "commander": "^6.2.0",
+    "commander": "^8.3.0",
     "del": "^6.0.0",
     "mkdirp": "^1.0.4",
     "pngjs": "^6.0.0",
     "sharp": "^0.29.3",
-    "svg2png": "4.1.1",
-    "uuid": "^8.3.1"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.2",
-    "@types/jest": "^26.0.16",
-    "@types/mkdirp": "^1.0.1",
-    "@types/node": "^14.14.10",
-    "@types/pngjs": "^3.4.2",
-    "@types/sharp": "^0.29.3",
-    "@types/svg2png": "^4.1.0",
-    "@types/uuid": "^8.3.0",
-    "jest": "^26.6.3",
-    "ts-jest": "^26.4.4",
-    "typescript": "^4.1.2"
+    "@types/jest": "^27.0.3",
+    "@types/mkdirp": "^1.0.2",
+    "@types/node": "^16.11.11",
+    "@types/pngjs": "^6.0.1",
+    "@types/sharp": "^0.29.4",
+    "@types/uuid": "^8.3.3",
+    "jest": "^27.4.3",
+    "ts-jest": "^27.0.7",
+    "typescript": "^4.5.2"
   }
 }


### PR DESCRIPTION
Also, note in the README that the SVG to PNG engine has been changed.
refs #122 #137 