### PR TITLE
update sharp

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "del": "^6.0.0",
     "mkdirp": "^1.0.4",
     "pngjs": "^6.0.0",
-    "sharp": "^0.29.3",
+    "sharp": "^0.30.4",
     "uuid": "^8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a bug when trying to use this package inside a docker container on a m1 mac. The older version of sharp cause npm install to simply fail.