### PR TITLE
refactor: simplify unit test

### DIFF
--- a/src/lib/favicon.test.ts
+++ b/src/lib/favicon.test.ts
@@ -1,6 +1,5 @@
-import assert from 'assert'
-import path from 'path'
-import fs from 'fs'
+import path from 'node:path'
+import fs from 'node:fs'
 import Logger from './logger'
 import generateFavicon, {
   REQUIRED_IMAGE_SIZES,
@@ -25,38 +24,36 @@ const deleteFiles = (paths: string[]) => {
   })
 }
 
-describe('Favicon', () => {
-  it('generateFavicon', () => {
-    const images = REQUIRED_IMAGE_SIZES.map((size) => {
-      const filePath = path.join('./examples/data', size + '.png')
-      return { size, filePath }
-    })
-
-    return generateFavicon(images, './examples/data', new Logger(), {
-      name: '',
-      pngSizes: [],
-      icoSizes: []
-    }).then((results) => {
-      assert(results.length === 11)
-      deleteFiles(results)
-    })
+test('generateFavicon', () => {
+  const images = REQUIRED_IMAGE_SIZES.map((size) => {
+    const filePath = path.join('./examples/data', size + '.png')
+    return { size, filePath }
   })
 
-  it('generatePNG', () => {
-    const images = REQUIRED_PNG_SIZES.map((size) => {
-      const filePath = path.join('./examples/data', size + '.png')
-      return { size, filePath }
-    })
+  return generateFavicon(images, './examples/data', new Logger(), {
+    name: '',
+    pngSizes: [],
+    icoSizes: []
+  }).then((results) => {
+    expect(results.length).toBe(11)
+    deleteFiles(results)
+  })
+})
 
-    return generatePNG(
-      images,
-      './examples/data',
-      'favicon-',
-      REQUIRED_PNG_SIZES,
-      new Logger()
-    ).then((results) => {
-      assert(results.length === 10)
-      deleteFiles(results)
-    })
+test('generatePNG', () => {
+  const images = REQUIRED_PNG_SIZES.map((size) => {
+    const filePath = path.join('./examples/data', size + '.png')
+    return { size, filePath }
+  })
+
+  return generatePNG(
+    images,
+    './examples/data',
+    'favicon-',
+    REQUIRED_PNG_SIZES,
+    new Logger()
+  ).then((results) => {
+    expect(results.length).toBe(10)
+    deleteFiles(results)
   })
 })

--- a/src/lib/icns.test.ts
+++ b/src/lib/icns.test.ts
@@ -1,24 +1,23 @@
-import assert from 'assert'
-import fs from 'fs'
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
 import Logger from './logger'
 import generateICNS, { REQUIRED_IMAGE_SIZES } from './icns'
 
-describe('ICNS', () => {
-  it('generateICNS', () => {
-    const images = REQUIRED_IMAGE_SIZES.map((size) => {
-      const filePath = path.join('./examples/data', size + '.png')
-      return { size, filePath }
-    })
+test('generateICNS', () => {
+  const images = REQUIRED_IMAGE_SIZES.map((size) => {
+    const filePath = path.join('./examples/data', size + '.png')
+    return { size, filePath }
+  })
 
-    return generateICNS(images, './examples/data', new Logger(), {
-      name: '',
-      sizes: []
-    }).then((filePath) => {
-      assert(filePath)
-      // output file size must be at least larger than input file size
-      assert(fs.statSync(filePath).size > fs.statSync(images[images.length - 1].filePath).size);
-      fs.unlinkSync(filePath)
-    })
+  return generateICNS(images, './examples/data', new Logger(), {
+    name: '',
+    sizes: []
+  }).then((filePath) => {
+    // output file size must be at least larger than input file size
+    expect(
+      fs.statSync(filePath).size >
+        fs.statSync(images[images.length - 1].filePath).size
+    ).toBe(true)
+    fs.unlinkSync(filePath)
   })
 })

--- a/src/lib/ico.test.ts
+++ b/src/lib/ico.test.ts
@@ -1,21 +1,20 @@
-import assert from 'assert'
-import fs from 'fs'
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
 import Logger from './logger'
 import generateICO, { REQUIRED_IMAGE_SIZES } from './ico'
 
-describe('ICO', () => {
-  it('generateICO', () => {
-    const targets = REQUIRED_IMAGE_SIZES.map((size) => {
-      const filePath = path.join('./examples/data', size + '.png')
-      return { size, filePath }
-    })
+it('generateICO', () => {
+  const targets = REQUIRED_IMAGE_SIZES.map((size) => {
+    const filePath = path.join('./examples/data', size + '.png')
+    return { size, filePath }
+  })
 
-    generateICO(targets, './examples/data', new Logger(), {}).then((result) => {
-      assert(result)
-      // output file size must be at least larger than input file size
-      assert(fs.statSync(result).size > fs.statSync(targets[targets.length - 1].filePath).size);
-      fs.unlinkSync(result)
-    })
+  generateICO(targets, './examples/data', new Logger(), {}).then((result) => {
+    // output file size must be at least larger than input file size
+    expect(
+      fs.statSync(result).size >
+        fs.statSync(targets[targets.length - 1].filePath).size
+    ).toBe(true)
+    fs.unlinkSync(result)
   })
 })

--- a/src/lib/png.test.ts
+++ b/src/lib/png.test.ts
@@ -1,52 +1,46 @@
-import assert from 'assert'
-import os from 'os'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
 import { v4 as uuidv4 } from 'uuid'
-import path from 'path'
-import fs from 'fs'
-import del from 'del'
 import Logger from './logger'
 import generatePNG, { filterImagesBySizes } from './png'
 import { REQUIRED_IMAGE_SIZES as FAV_SIZES } from './favicon'
 import { REQUIRED_IMAGE_SIZES as ICNS_SIZES } from './icns'
 import { REQUIRED_IMAGE_SIZES as ICO_SIZES } from './ico'
 
-describe('PNG', () => {
-  describe('generatePNG', () => {
-    it('Generate', () => {
-      const dir = path.join(os.tmpdir(), uuidv4())
-      fs.mkdirSync(dir)
+test('generatePNG', () => {
+  const dir = path.join(os.tmpdir(), uuidv4())
+  fs.mkdirSync(dir)
 
-      return generatePNG('./examples/data/sample.svg', dir, [16], new Logger())
-        .then((results) => {
-          assert(results[0].size === 16)
-          del.sync([dir], { force: true })
-        })
-        .catch((err) => {
-          console.error(err)
-          del.sync([dir], { force: true })
-        })
+  return generatePNG('./examples/data/sample.svg', dir, [16], new Logger())
+    .then((results) => {
+      expect(results[0].size).toBe(16)
+      fs.rmSync(dir, { recursive: true, force: true })
     })
-  })
+    .catch((err) => {
+      console.error(err)
+      fs.rmSync(dir, { recursive: true, force: true })
+    })
+})
 
-  describe('filterImagesBySizes', () => {
-    const targets = ICO_SIZES.concat(ICNS_SIZES)
-      .concat(FAV_SIZES)
-      .filter((value, index, array) => array.indexOf(value) === index)
-      .sort((a, b) => a - b)
-      .map((size) => ({ size, filePath: '' }))
+// Test data
+const targets = ICO_SIZES.concat(ICNS_SIZES)
+  .concat(FAV_SIZES)
+  .filter((value, index, array) => array.indexOf(value) === index)
+  .sort((a, b) => a - b)
+  .map((size) => ({ size, filePath: '' }))
 
-    it('ICO', () => {
-      const sizes = filterImagesBySizes(targets, ICO_SIZES)
-      assert.strictEqual(sizes.length, ICO_SIZES.length)
-    })
+test('filterImagesBySizes: ICO', () => {
+  const sizes = filterImagesBySizes(targets, ICO_SIZES)
+  expect(sizes.length).toBe(ICO_SIZES.length)
+})
 
-    it('ICNS', () => {
-      const sizes = filterImagesBySizes(targets, ICNS_SIZES)
-      assert.strictEqual(sizes.length, ICNS_SIZES.length)
-    })
-    it('Favicon', () => {
-      const sizes = filterImagesBySizes(targets, FAV_SIZES)
-      assert.strictEqual(sizes.length, FAV_SIZES.length)
-    })
-  })
+test('filterImagesBySizes: ICNS', () => {
+  const sizes = filterImagesBySizes(targets, ICNS_SIZES)
+  expect(sizes.length).toBe(ICNS_SIZES.length)
+})
+
+test('filterImagesBySizes: Favicon', () => {
+  const sizes = filterImagesBySizes(targets, FAV_SIZES)
+  expect(sizes.length).toBe(FAV_SIZES.length)
 })

--- a/src/lib/rle.test.ts
+++ b/src/lib/rle.test.ts
@@ -1,131 +1,46 @@
-import assert from 'assert'
 import { packBits, packICNS, unpackBits, packBitsLiteralToResult } from './rle'
 
-describe('RLE', () => {
-  describe('packBits', () => {
-    it('Normaly', () => {
-      // Sample data : https://en.wikipedia.org/wiki/PackBits
-      const src = [
-        0xaa,
-        0xaa,
-        0xaa,
-        0x80,
-        0x00,
-        0x2a,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0x80,
-        0x00,
-        0x2a,
-        0x22,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa
-      ]
-      const expected = [
-        0xfe,
-        0xaa,
-        0x02,
-        0x80,
-        0x00,
-        0x2a,
-        0xfd,
-        0xaa,
-        0x03,
-        0x80,
-        0x00,
-        0x2a,
-        0x22,
-        0xf7,
-        0xaa
-      ]
-      const actual = packBits(src)
-      assert.deepStrictEqual(actual, expected)
-    })
-  })
+it('packBits', () => {
+  // Sample data : https://en.wikipedia.org/wiki/PackBits
+  const src = [
+    0xaa, 0xaa, 0xaa, 0x80, 0x00, 0x2a, 0xaa, 0xaa, 0xaa, 0xaa, 0x80, 0x00,
+    0x2a, 0x22, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
+  ]
+  const expected = [
+    0xfe, 0xaa, 0x02, 0x80, 0x00, 0x2a, 0xfd, 0xaa, 0x03, 0x80, 0x00, 0x2a,
+    0x22, 0xf7, 0xaa
+  ]
+  const actual = packBits(src)
+  expect(actual).toStrictEqual(expected)
+})
 
-  describe('packICNS', () => {
-    it('Normaly', () => {
-      const src = [0, 0, 0, 249, 250, 128, 100, 101]
-      const actual = packICNS(src)
-      const expected = [128, 0, 4, 249, 250, 128, 100, 101]
-      assert.deepStrictEqual(actual, expected)
-    })
-  })
+it('packICNS', () => {
+  const src = [0, 0, 0, 249, 250, 128, 100, 101]
+  const actual = packICNS(src)
+  const expected = [128, 0, 4, 249, 250, 128, 100, 101]
+  expect(actual).toStrictEqual(expected)
+})
 
-  describe('unpackBits', () => {
-    it('Normaly', () => {
-      // Sample data : https://en.wikipedia.org/wiki/PackBits
-      const src = [
-        0xfe,
-        0xaa,
-        0x02,
-        0x80,
-        0x00,
-        0x2a,
-        0xfd,
-        0xaa,
-        0x03,
-        0x80,
-        0x00,
-        0x2a,
-        0x22,
-        0xf7,
-        0xaa
-      ]
-      const expected = [
-        0xaa,
-        0xaa,
-        0xaa,
-        0x80,
-        0x00,
-        0x2a,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0x80,
-        0x00,
-        0x2a,
-        0x22,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa,
-        0xaa
-      ]
-      const actual = unpackBits(src)
-      assert.deepStrictEqual(actual, expected)
-    })
-  })
-  /** @test {packBitsLiteralToResult} */
-  describe('_packBitsLiteralToResult', () => {
-    it('Normaly', () => {
-      assert.deepStrictEqual(packBitsLiteralToResult([7, 1, 5, 8]), [
-        3,
-        7,
-        1,
-        5,
-        8
-      ])
-    })
+it('unpackBits', () => {
+  // Sample data : https://en.wikipedia.org/wiki/PackBits
+  const src = [
+    0xfe, 0xaa, 0x02, 0x80, 0x00, 0x2a, 0xfd, 0xaa, 0x03, 0x80, 0x00, 0x2a,
+    0x22, 0xf7, 0xaa
+  ]
+  const expected = [
+    0xaa, 0xaa, 0xaa, 0x80, 0x00, 0x2a, 0xaa, 0xaa, 0xaa, 0xaa, 0x80, 0x00,
+    0x2a, 0x22, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
+  ]
+  const actual = unpackBits(src)
+  expect(actual).toStrictEqual(expected)
+})
 
-    it('Empty', () => {
-      assert.deepStrictEqual(packBitsLiteralToResult([]), [])
-    })
-  })
+it('_packBitsLiteralToResult', () => {
+  const actual = packBitsLiteralToResult([7, 1, 5, 8])
+  const expected = [3, 7, 1, 5, 8]
+  expect(actual).toStrictEqual(expected)
+})
+
+it('_packBitsLiteralToResult: Empty', () => {
+  expect(packBitsLiteralToResult([])).toStrictEqual([])
 })


### PR DESCRIPTION
- Remove `describe
- Use Jest standard API instead of `assert
- Use the new Node.js fs instead of `del`
