### PR TITLE
refactor: replace `del` with `fs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "commander": "^8.3.0",
-    "del": "^6.0.0",
     "mkdirp": "^1.0.4",
     "pngjs": "^6.0.0",
     "sharp": "^0.30.4",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,5 @@
 import fs from 'fs'
 import path from 'path'
-import del from 'del'
 import os from 'os'
 import { v4 as uuidv4 } from 'uuid'
 import mkdirP from 'mkdirp'
@@ -220,10 +219,10 @@ const generateIconFromSVG = async (
       logger
     )
     const results = await generate(images, destDirPath, options, logger)
-    del.sync([workDir], { force: true })
+    fs.rmSync(workDir, {force: true, recursive: true})
     return results
   } catch (err) {
-    del.sync([workDir], { force: true })
+    fs.rmSync(workDir, {force: true, recursive: true})
     throw err
   }
 }


### PR DESCRIPTION
`rmSync` was added to `fs` on Node 16. This can replace the function of `del`.