### PR TITLE
refactor: replace `mkdirp` with `fs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,14 +41,11 @@
   },
   "dependencies": {
     "commander": "^8.3.0",
-    "mkdirp": "^1.0.4",
     "pngjs": "^6.0.0",
     "sharp": "^0.30.4",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/cross-spawn": "^6.0.2",
-    "@types/mkdirp": "^1.0.2",
     "@types/node": "^18.16.3",
     "@types/pngjs": "^6.0.1",
     "@types/sharp": "^0.30.2",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,8 +1,7 @@
-import fs from 'fs'
-import path from 'path'
-import os from 'os'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
 import { v4 as uuidv4 } from 'uuid'
-import mkdirP from 'mkdirp'
 import generatePNG, { ImageInfo } from './png'
 import generateICO, { REQUIRED_IMAGE_SIZES as ICO_SIZES } from './ico'
 import generateICNS, { REQUIRED_IMAGE_SIZES as ICNS_SIZES } from './icns'
@@ -117,7 +116,7 @@ const generate = async (
   }
 
   const dir = path.resolve(dest)
-  mkdirP.sync(dir)
+  fs.mkdirSync(dir, {recursive: true})
 
   const results: string[] = []
   if (options.icns) {


### PR DESCRIPTION
`mkdirSync` with `recursive` option was added to `fs` on Node 16. This can replace the function of `mkdirp`.